### PR TITLE
Fix missing mx-auto in all sections

### DIFF
--- a/src/components/landing/cta-section.tsx
+++ b/src/components/landing/cta-section.tsx
@@ -4,7 +4,7 @@ import { Github, ArrowRight } from "lucide-react"
 export function CTASection() {
   return (
     <section className="py-16 sm:py-20 lg:py-24 xl:py-32">
-      <div className="container px-4 sm:px-6">
+      <div className="container px-4 sm:px-6 mx-auto">
         <div className="relative overflow-hidden rounded-xl sm:rounded-2xl border border-border/40 bg-gradient-to-r from-primary/10 to-primary/5 p-6 sm:p-8 lg:p-12 text-center backdrop-blur">
           <div className="absolute inset-0 grid-bg dark:grid-bg opacity-30" />
           <div className="relative">

--- a/src/components/landing/features-section.tsx
+++ b/src/components/landing/features-section.tsx
@@ -27,7 +27,7 @@ const features = [
 export function FeaturesSection() {
   return (
     <section id="features" className="py-16 sm:py-20 lg:py-24 xl:py-32">
-      <div className="container px-4 sm:px-6">
+      <div className="container px-4 sm:px-6 mx-auto">
         <div className="mx-auto max-w-2xl text-center mb-12 sm:mb-16">
           <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight text-balance leading-tight">
             Everything you need (and nothing you don't)

--- a/src/components/landing/footer.tsx
+++ b/src/components/landing/footer.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 export function Footer() {
   return (
     <footer className="border-t border-border/40 bg-background/95 backdrop-blur">
-      <div className="container py-12 sm:py-16 px-4 sm:px-6">
+      <div className="container py-12 sm:py-16 px-4 sm:px-6 mx-auto">
         <div className="grid gap-6 sm:gap-8 grid-cols-1 md:grid-cols-3">
           <div className="md:col-span-2">
             <div className="flex items-center space-x-2 mb-4">

--- a/src/components/landing/header.tsx
+++ b/src/components/landing/header.tsx
@@ -5,7 +5,7 @@ import { ThemeToggle } from "@/components/landing/theme-toggle"
 export function Header() {
   return (
     <header className="border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container flex h-14 max-w-screen-2xl items-center px-4 sm:px-6">
+      <div className="container flex h-14 max-w-screen-2xl items-center px-4 sm:px-6 mx-auto">
         <div className="flex">
           <a className="mr-4 sm:mr-6 flex items-center space-x-2" href="/">
             <span className="font-bold text-lg sm:text-xl bg-gradient-to-r from-orange-600 to-orange-700 bg-clip-text text-transparent">

--- a/src/components/landing/hero-section.tsx
+++ b/src/components/landing/hero-section.tsx
@@ -5,7 +5,7 @@ export function HeroSection() {
   return (
     <section className="relative overflow-hidden py-8 lg:py-28">
       <div className="absolute inset-0 grid-bg opacity-30" />
-      <div className="container relative px-4 sm:px-6">
+      <div className="container relative px-4 sm:px-6 mx-auto">
         <div className="mx-auto max-w-4xl text-center">
           <div className="mb-6 sm:mb-8 inline-flex items-center rounded-full border border-border/40 bg-muted/50 px-3 py-1 text-xs sm:text-sm">
             <span className="mr-1 sm:mr-2">🔥</span>

--- a/src/components/landing/wall-of-fame.tsx
+++ b/src/components/landing/wall-of-fame.tsx
@@ -116,7 +116,7 @@ export function WallOfFame({ limit = 6 }: WallOfFameProps) {
   if (error || portfolios.length === 0) {
     return (
       <section className="py-16 sm:py-20 lg:py-24">
-        <div className="container px-4 sm:px-6">
+        <div className="container px-4 sm:px-6 mx-auto">
           <div className="mx-auto max-w-2xl text-center">
             <motion.div
               initial={{ opacity: 0, y: 20 }}

--- a/src/components/landing/wall-of-fame.tsx
+++ b/src/components/landing/wall-of-fame.tsx
@@ -103,7 +103,7 @@ export function WallOfFame({ limit = 6 }: WallOfFameProps) {
   if (loading) {
     return (
       <section className="py-16 sm:py-20 lg:py-24">
-        <div className="container px-4 sm:px-6">
+        <div className="container px-4 sm:px-6 mx-auto">
           <div className="flex justify-center items-center py-12">
             <Loader2 className="h-8 w-8 animate-spin text-primary" />
             <span className="ml-2 text-muted-foreground">Loading live portfolios...</span>
@@ -155,7 +155,7 @@ export function WallOfFame({ limit = 6 }: WallOfFameProps) {
 
   return (
     <section className="py-16 sm:py-20 lg:py-24">
-      <div className="container px-4 sm:px-6">
+      <div className="container px-4 sm:px-6 mx-auto">
         <div className="mx-auto max-w-2xl text-center mb-12 sm:mb-16">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -210,7 +210,7 @@ export function WallOfFame({ limit = 6 }: WallOfFameProps) {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.3 + index * 0.1 }}
             >
-              <Link href={portfolio.portfolioUrl} target="_blank" className="block">
+              <Link href={portfolio.portfolioUrl} target="_blank" className="block h-full">
                 <Card className="group hover:shadow-xl transition-all duration-300 border-border/40 bg-card/50 backdrop-blur h-full cursor-pointer">
                   <CardContent className="p-6 h-full flex flex-col">
                     {/* Header */}


### PR DESCRIPTION
Added missing mx-auto to components where horizontal centering was broken.

Before:
<img width="1699" height="984" alt="Screenshot 2025-10-26 at 5 00 14 PM" src="https://github.com/user-attachments/assets/4b61b7fa-8115-4e12-afb8-1e487991f73c" />

After I centered:
<img width="1702" height="982" alt="Screenshot 2025-10-26 at 5 00 50 PM" src="https://github.com/user-attachments/assets/6d39000b-6aaf-4088-ae5a-8013bc45b803" />

